### PR TITLE
Fix issue with QuantumState.draw() when show_qubit_index is set to False

### DIFF
--- a/QIRT/latex_drawer.py
+++ b/QIRT/latex_drawer.py
@@ -385,7 +385,7 @@ def _latex_line_break(latex_code: str, output_length: int = 2) -> str:
     """
     latex_code = latex_code.replace("|", "&|")
     max_term = 2**output_length
-    rangle_terms = re.findall(r"\\rangle(?:_{\d+(?:,\d+)*})?", latex_code)
+    rangle_terms = re.findall(r"\\rangle_\{(?:[0-9](?:,[0-9])*)?\}", latex_code)
     for i in range(max_term, len(rangle_terms), max_term):
         rangle_term = rangle_terms[i - 1]
         new_line_index = find_nth_substring(latex_code, rangle_term, i) + len(rangle_term)

--- a/QIRT/quantum_circuit.py
+++ b/QIRT/quantum_circuit.py
@@ -1238,6 +1238,8 @@ class QuantumCircuit:
                 q_1: ┤1                                          ├
                      └───────────────────────────────────────────┘
         """
+        from QIRT import QuantumState
+
         if isinstance(state, QuantumState):
             state = state.state_vector
         self._qiskit_qc.prepare_state(state, qubits=qubits, label=label, normalize=normalize)
@@ -1342,6 +1344,8 @@ class QuantumCircuit:
                 q_1: ┤1                                   ├
                      └────────────────────────────────────┘
         """
+        from QIRT import QuantumState
+
         if isinstance(params, QuantumState):
             params = params.state_vector
         self._qiskit_qc.initialize(params, qubits=qubits, normalize=normalize)

--- a/QIRT/quantum_state.py
+++ b/QIRT/quantum_state.py
@@ -244,13 +244,21 @@ class QuantumState:
 
         Args:
             output (str, optional): Visualization method. Defaults to "latex". Options include:
-                - "matrix" or "vector": Outputs the state vector as a LaTeX formatted matrix.
-                - "latex": Outputs the state vector as a LaTeX formatted expression.
+                - "matrix" or "vector": Outputs the QuantumState as a LaTeX formatted matrix.
+                - "latex": Outputs the QuantumState as a LaTeX formatted expression.
+                - "repr": ASCII TextMatrix of the QuantumState's `__repr__`.
+                - "text": ASCII TextMatrix that can be printed in the console.
+                - "qsphere": Matplotlib figure rendering the QuantumState using `plot_state_qsphere()`.
+                - "hinton": Matplotlib figure rendering the QuantumState using `plot_state_hinton()`.
+                - "bloch": Matplotlib figure rendering the QuantumState using `plot_bloch_multivector()`.
+                - "city": Matplotlib figure rendering the QuantumState using `plot_state_city()`.
+                - "paulivec": Matplotlib figure rendering the QuantumState using `plot_state_paulivec()`.
             target_basis (List[str] | str | None, optional): The target basis for visualization. Defaults to None.
             show_qubit_index (bool, optional): Whether to show qubit indices in the visualization. Defaults to True.
             output_length (int, optional): The number of terms in each line, defined as 2^output_length.
-                                        Defaults to 2 (i.e., 4 terms per line).
-            source (bool, optional): Whether to return the latex source code for the visualization. Defaults to False.
+                Defaults to 2 (i.e., 4 terms per line).
+            source (bool, optional): Whether to return the latex source code for the visualization option "matrix" and
+                "latex". Defaults to False.
 
         Returns:
             (matplotlib.Figure | str | TextMatrix | IPython.display.Latex | Latex): The visualization
@@ -268,6 +276,11 @@ class QuantumState:
                     output_length=output_length,
                     source=source,
                 )
+            case "repr" | "text" | "qsphere" | "hinton" | "city" | "paulivec":
+                return self.state_vector.draw(output=output)
+            case "bloch":
+                reversed_state_vector = self.state_vector.reverse_qargs()
+                return reversed_state_vector.draw(output=output)
             case _:
                 raise QiskitError("Invalid output format.")
 

--- a/QIRT/quantum_state.py
+++ b/QIRT/quantum_state.py
@@ -55,6 +55,8 @@ class QuantumState:
         [Qiskit Statevector documentation](https://qiskit.org/documentation/stubs/qiskit.quantum_info.Statevector.html)
     """
 
+    # TODO: Add Bell measurement method.
+
     def __init__(
         self,
         data: np.ndarray | list | Statevector | Operator | QiskitQC | Instruction,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ final_state.draw()
 For detailed documentation, tutorials, and how-to guides, visit our [documentation website](https://slope86.github.io/QIRT/).
 
 - [Tutorials](https://slope86.github.io/QIRT/tutorials): Learn the basics of QIRT with hands-on examples.
-- [How-To Guides](https://slope86.github.io/QIRT/how_to_guides): Step-by-step instructions for specific tasks.
+- [How-To Guides](https://slope86.github.io/QIRT/how_to_guides): Detailed instructions for specific tasks.
 - [API Reference](https://slope86.github.io/QIRT/reference): Detailed descriptions of QIRT functions, classes, and modules.
 
 ## Requirements


### PR DESCRIPTION
When running QuantumState.draw() with show_qubit_index=False, a ParseError is raised. This pull request fixes the issue by updating the regex pattern for rangle_terms in the _latex_line_break function. Additionally, it refactors the import of the QuantumState class in the quantum_circuit.py initialize() and prepare_state() methods, improves QuantumState visualization options, and updates the README.md file. It also adds a TODO for the Bell measurement method to the QuantumState class.

Fixes #4