### PR TITLE
Improve quantum measurement method reliability

### DIFF
--- a/QIRT/latex_drawer.py
+++ b/QIRT/latex_drawer.py
@@ -252,7 +252,7 @@ def _state_to_latex_ket(
         Returns:
             str: The converted ket name.
         """
-        ket_01 = bin(i)[2:].zfill(state.num_of_qubit)
+        ket_01 = format(i, f'0{state.num_of_qubit}b')
         ket_name = ""
         for b, k, i in zip(convert_basis, ket_01, qubit_index):
             if i in hidden_bit:

--- a/QIRT/latex_drawer.py
+++ b/QIRT/latex_drawer.py
@@ -243,20 +243,28 @@ def _state_to_latex_ket(
     else:
         qubit_index_str = ""
 
-    def ket_name(i):
-        ket = bin(i)[2:].zfill(state.num_of_qubit)
-        new_ket = ""
-        for b, k, i in zip(convert_basis, ket, qubit_index):
+    def ket_name(i: int) -> str:
+        """Convert 0, 1 (int) to "0", "1" or "+", "-" or "i", "-i" (str) based on the basis.
+
+        Args:
+            i (int): The integer to convert.
+
+        Returns:
+            str: The converted ket name.
+        """
+        ket_01 = bin(i)[2:].zfill(state.num_of_qubit)
+        ket_name = ""
+        for b, k, i in zip(convert_basis, ket_01, qubit_index):
             if i in hidden_bit:
                 continue
             match b:
                 case "z":
-                    new_ket += Ket.z1 if int(k) else Ket.z0
+                    ket_name += Ket.z1 if int(k) else Ket.z0
                 case "x":
-                    new_ket += Ket.x1 if int(k) else Ket.x0
+                    ket_name += Ket.x1 if int(k) else Ket.x0
                 case "y":
-                    new_ket += Ket.y1 if int(k) else Ket.y0
-        return new_ket
+                    ket_name += Ket.y1 if int(k) else Ket.y0
+        return ket_name
 
     data = np.around(data, 15)
     nonzero_indices = np.where(data != 0)[0].tolist()

--- a/QIRT/utils/ket.py
+++ b/QIRT/utils/ket.py
@@ -132,3 +132,23 @@ class Ket(metaclass=_ConfigMeta):
         label = label.replace(Ket.y0, "r")
         label = label.replace(Ket.y1, "l")
         return label
+
+    @classmethod
+    def from_basis_and_label(cls, basis: str, label: str) -> str:
+        """Convert the basis and label to the custom ket notation.
+
+        Args:
+            basis (str): Ket basis to use for conversion.
+            label (str): Ket label to convert.
+
+        Returns:
+            str: The converted ket notation.
+        """
+        if basis == "z":
+            return Ket.z1 if int(label) else Ket.z0
+        elif basis == "x":
+            return Ket.x1 if int(label) else Ket.x0
+        elif basis == "y":
+            return Ket.y1 if int(label) else Ket.y0
+        else:
+            raise ValueError(f"Invalid basis [{basis}]. Basis should be z, x, or y.")

--- a/docs/how_to_guides/post_measurement_states.md
+++ b/docs/how_to_guides/post_measurement_states.md
@@ -10,7 +10,7 @@ The `state_after_measurement` function allows you to simulate quantum measuremen
 
 ```python
 def state_after_measurement(
-    self, measure_bit: list[int] | str, target_basis: list[str] | str = [], shot=100
+    self, measure_bit: list[int] | str, target_basis: list[str] | str = []
 ) -> list[QuantumState]:
 ```
 
@@ -19,8 +19,6 @@ def state_after_measurement(
 1. `measure_bit`: List of integers or string specifying which qubits to measure. For example, [0, 2] or "02" would measure the first and third qubits.
 
 2. `target_basis`: List or string determining the measurement basis for measured qubits. Each element corresponds to a measured qubit. Default is Z-basis for all measured qubits.
-
-3. `shot`: Number of measurement simulations to perform. Higher values give more accurate probability distributions. Defaults to 100.
 
 ### Return Value
 

--- a/tests/test_quantum_state.py
+++ b/tests/test_quantum_state.py
@@ -17,14 +17,15 @@ Y1 = Ket.y1
 
 
 def test_from_label():
+    """Test the creation of a quantum state from a label."""
     # (|00> + |11>) / sqrt(2)
-    Bell_state_Z = QuantumState.from_label((Z0 + Z0), (Z1 + Z1))
+    bell_state_z = QuantumState.from_label((Z0 + Z0), (Z1 + Z1))
     # (|++> + |-->) / sqrt(2)
-    Bell_state_X = QuantumState.from_label((X0 + X0), (X1 + X1))
+    bell_state_x = QuantumState.from_label((X0 + X0), (X1 + X1))
 
     expected_state_data = np.array([0.70710678 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.70710678 + 0.0j])
-    assert np.allclose(Bell_state_Z.data, expected_state_data, atol=ABS_TOL)
-    assert np.allclose(Bell_state_X.data, expected_state_data, atol=ABS_TOL)
+    assert np.allclose(bell_state_z.data, expected_state_data, atol=ABS_TOL)
+    assert np.allclose(bell_state_x.data, expected_state_data, atol=ABS_TOL)
 
     # (|0+> + |1->) / sqrt(2)
     graph_state = QuantumState.from_label((Z0 + X0), (Z1 + X1))
@@ -40,24 +41,26 @@ def test_from_label():
 
 
 def test_entropy():
+    """Test the calculation of the entropy of a quantum state."""
     # |000>
     state = QuantumState.from_label(Z0 * 3)
     assert math.isclose(state.entropy(), 0.0, abs_tol=ABS_TOL)
 
     # |0+0> + |0-0>
-    stateZXZ = state._basis_convert("-x-")[0]
-    assert math.isclose(stateZXZ.entropy(), 1.0, abs_tol=ABS_TOL)
+    state_zxz = state._basis_convert("-x-")[0]
+    assert math.isclose(state_zxz.entropy(), 1.0, abs_tol=ABS_TOL)
 
     # |r0r> + |r0l> + |l0r> + |l0l>
-    stateYZY = state._basis_convert("y-y")[0]
-    assert math.isclose(stateYZY.entropy(), 2.0, abs_tol=ABS_TOL)
+    state_yzy = state._basis_convert("y-y")[0]
+    assert math.isclose(state_yzy.entropy(), 2.0, abs_tol=ABS_TOL)
 
     # |000>
-    stateZZZ = state._basis_convert("")[0]
-    assert math.isclose(stateZZZ.entropy(), 0.0, abs_tol=ABS_TOL)
+    state_zzz = state._basis_convert("")[0]
+    assert math.isclose(state_zzz.entropy(), 0.0, abs_tol=ABS_TOL)
 
 
 def test_to_matrix():
+    """Test the conversion of a quantum state to a matrix."""
     test_state_vector: NDArray
     expect_state_vector: NDArray
 
@@ -99,11 +102,49 @@ def test_to_matrix():
     # |i>
     test_state_vector = QuantumState.from_label(Y0).to_matrix().squeeze()
     expect_state_vector = np.array([1 + 0j, 0 + 1j]) / math.sqrt(2)
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
 
     # |j>
     test_state_vector = QuantumState.from_label(Y1).to_matrix().squeeze()
     expect_state_vector = np.array([1 + 0j, 0 - 1j]) / math.sqrt(2)
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
 
     # |0i> + |1j>
     test_state_vector = QuantumState.from_label(Z0 + Y0, Z1 + Y1).to_matrix().squeeze()
     expect_state_vector = np.array([1 + 0j, 0 + 1j, 1 + 0j, 0 - 1j]) / 2
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
+
+
+def test_state_after_measurement():
+    """Test measuring method."""
+    # |000> + |1-->
+    state = QuantumState.from_label(Z0 * 3, Z1 + X1 * 2)
+
+    # Measure the first qubit in the Z basis
+    result_state_list = state.state_after_measurement(measure_bit=[0], target_basis="z--")
+
+    # |0>: |000>
+    test_state_vector = result_state_list[0].to_matrix().squeeze()
+    expect_state_vector = np.array([1, 0, 0, 0, 0, 0, 0, 0])
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
+
+    # |1>: |1-->
+    test_state_vector = result_state_list[1].to_matrix().squeeze()
+    expect_state_vector = np.array(
+        [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.5 + 0.0j, -0.5 + 0.0j, -0.5 + 0.0j, 0.5 + 0.0j]
+    )
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
+
+    # |+->
+    state = QuantumState.from_label(X0 + X1)
+
+    # Measure the first qubit in the X basis
+    result_state_list = state.state_after_measurement(measure_bit=[0], target_basis="x-")
+
+    # |+>: |+->
+    test_state_vector = result_state_list[0].to_matrix().squeeze()
+    expect_state_vector = np.array([ 0.5+0.j, -0.5+0.j,  0.5+0.j, -0.5+0.j])
+    assert np.allclose(test_state_vector, expect_state_vector, atol=ABS_TOL)
+
+    # |->: None
+    assert result_state_list[1] is None


### PR DESCRIPTION
## Description
Replaced the current measurement method that uses multiple Qiskit measurement API calls with a more robust approach using projection operators. This change ensures we capture all possible measurement outcomes by applying projection operators for each possible outcome to the quantum state.

## Changes
- Implemented new measurement method using projection operators
- Removed multiple shots measurement approach
- Updated related test cases

## Related Issues
Related to #8